### PR TITLE
Add formula parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.12)
 project(pddl_parser VERSION 0.9.0
 	DESCRIPTION "Basic PDDL parser based on boost spirit")
 
+add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
+
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(spdlog REQUIRED)
 

--- a/include/pddl_parser/pddl_grammar.h
+++ b/include/pddl_parser/pddl_grammar.h
@@ -273,10 +273,10 @@ struct domain_parser : qi::grammar<Iterator, Domain(), Skipper>
 		           | hold[durative_expression] | hold[quantified_expression]
 		           | hold[cond_effect_expression] | hold[pred_expression] | hold[unknown_expression])]
 		  >> ')';
-		temp_breakup  = lit(":temporal-breakup") > expression;
-		cond_breakup  = lit(":conditional-breakup") > expression;
+		temp_breakup  = lit(":temporal-breakup") > precondition;
+		cond_breakup  = lit(":conditional-breakup") > precondition;
 		effects       = lit(":effect") > expression;
-		preconditions = (lit(":precondition") | lit(":condition")) > expression;
+		preconditions = (lit(":precondition") | lit(":condition")) > precondition;
 		duration      = lit(":duration") > '(' > '=' > lit("?duration")
 		           > (value_expression
 		              | ('(' > (hold[function_change_expression] | hold[pred_expression]) > ')'))
@@ -376,8 +376,10 @@ private:
 	qi::rule<Iterator, Expression(), Skipper> unknown_expression;
 	/** Named placeholder for parsing a PDDL expression. */
 	qi::rule<Iterator, Expression(), Skipper> expression;
-	/** Named placeholder for parsing a PDDL precondition. */
+	/** Named placeholder for parsing a PDDL preconditions. */
 	qi::rule<Iterator, Expression(), Skipper> preconditions;
+	/** Named placeholder for parsing a PDDL precondition. */
+	formula_parser<Iterator, Skipper> precondition;
 	/** Named placeholder for parsing a PDDL effect. */
 	qi::rule<Iterator, Expression(), Skipper> effects;
 	/** Named placeholder for parsing a temporal breakup. */

--- a/include/pddl_parser/pddl_grammar.h
+++ b/include/pddl_parser/pddl_grammar.h
@@ -63,21 +63,6 @@ struct formula_parser : qi::grammar<Iterator, Expression(), Skipper>
 
 		name_type = lexeme[alnum > *(alnum | char_('-') | char_('_'))];
 
-		// _r1: domain, _r2: parent list of pairs _val is parsed into
-		type_pair =
-		  (qr::iter_pos
-		   >> qi::as<pair_strings_type>()[+name_type
-		                                  > -('-' >> (qi::as<std::vector<std::string>>()[name_type]
-		                                              | ('(' > lit("either") > *name_type > ')')))])
-		    [_val = type_semantics_(qi::_1, param_transformer_(qi::_1, qi::_2, qi::_r2), qi::_r1)];
-
-		constant_value_list = +name_type;
-		// _r1: parent list of pairs _val is parsed into
-		constant_multi_pair =
-		  (qr::iter_pos >> qi::as<pair_multi_const>()[(constant_value_list > -('-' > name_type))])
-		    [_val =
-		       constant_semantics_(qi::_1, qi::_2, qi::_r1, px::bind(&formula_parser::warnings, this))];
-
 		// _r1: parent list of pairs _val is parsed into
 		param_pair =
 		  (qr::iter_pos
@@ -86,8 +71,6 @@ struct formula_parser : qi::grammar<Iterator, Expression(), Skipper>
 		                                              | ('(' > lit("either") > *name_type > ')')))])
 		    [_val = param_transformer_(qi::_1, qi::_2, qi::_r1)];
 		param_pairs = +param_pair(qi::_val);
-		pred        = '(' > name_type > -param_pairs > ')';
-		predicates  = '(' > lit(":predicates") > +pred > ')';
 
 		atom    = +(graph - '(' - ')');
 		bool_op = qi::string("and") | qi::string("or") | qi::string("not");
@@ -108,8 +91,6 @@ struct formula_parser : qi::grammar<Iterator, Expression(), Skipper>
 		  attr(ExpressionType::QUANTIFIED)
 		  >> qi::as<QuantifiedFormula>()[(qi::string("exists") | qi::string("forall")) > '('
 		                                 > param_pairs > ')' > formula];
-		cond_effect_expression = attr(ExpressionType::COND_EFFECT)
-		                         >> qi::as<Predicate>()[qi::string("when") > formula > formula];
 		durative_expression = attr(ExpressionType::DURATIVE)
 		                      >> qi::as<Predicate>()[(qi::string("at start") | qi::string("at end")
 		                                              | qi::string("over all"))
@@ -122,18 +103,11 @@ struct formula_parser : qi::grammar<Iterator, Expression(), Skipper>
 		                         > (hold[formula >> value_expression]
 		                            | hold[value_expression >> formula] | hold[formula >> formula]
 		                            | +(hold[attr(ExpressionType::ATOM) >> atom]))];
-		function_change_expression =
-		  attr(ExpressionType::NUMERIC_CHANGE)
-		  >> qi::as<Predicate>()[numerical_op
-		                         > (hold[formula >> value_expression]
-		                            | hold[value_expression >> formula] | hold[formula >> formula])];
-
 		// hold to backtrack the ExpressionType
 		formula =
 		  '('
-		  >> hold[(hold[bool_expression] | hold[function_expression] | hold[function_change_expression]
-		           | hold[durative_expression] | hold[quantified_expression]
-		           | hold[cond_effect_expression] | hold[pred_expression] | hold[unknown_expression])]
+		  >> hold[(hold[bool_expression] | hold[function_expression] | hold[durative_expression]
+		           | hold[quantified_expression] | hold[pred_expression] | hold[unknown_expression])]
 		  >> ')';
 	}
 
@@ -160,15 +134,9 @@ private:
 
 	/** Named placeholder for parsing types. Pass the domain for semantic checks. */
 	qi::rule<Iterator, pairs_type(const Domain &), Skipper> types;
-	/** Named placeholder for parsing type pairs. Pass the domain for semantic checks. */
-	qi::rule<Iterator, pair_type(const Domain &, string_pairs_type &), Skipper> type_pair;
 
-	/** Named placeholder for parsing a list of constant values. */
-	qi::rule<Iterator, type_list(), Skipper> constant_value_list;
 	/** Named placeholder for parsing a list of predicate parameters. */
 	qi::rule<Iterator, type_list(), Skipper> predicate_params;
-	/** Named placeholder for parsing a list of typed constants. Pass the domain for semantic checks. */
-	qi::rule<Iterator, pair_multi_const(const Domain &), Skipper> constant_multi_pair;
 	/** Named placeholder for parsing a list of constants. Pass the domain for semantic checks. */
 	qi::rule<Iterator, pairs_multi_consts(const Domain &), Skipper> constants;
 
@@ -176,10 +144,6 @@ private:
 	qi::rule<Iterator, string_pair_type(string_pairs_type &), Skipper> param_pair;
 	/** Named placeholder for parsing a list of parameter pairs. */
 	qi::rule<Iterator, string_pairs_type(), Skipper> param_pairs;
-	/** Named placeholder for parsing a predicate type. */
-	qi::rule<Iterator, predicate_type(), Skipper> pred;
-	/** Named placeholder for parsing a list of predicate types. */
-	qi::rule<Iterator, std::vector<predicate_type>(), Skipper> predicates;
 
 	/** Named placeholder for parsing any atom. */
 	qi::rule<Iterator, Atom()> atom;
@@ -191,24 +155,20 @@ private:
 	qi::rule<Iterator, Atom()> numerical_op;
 	/** Named placeholder for parsing a predicate. */
 	qi::rule<Iterator, Predicate(), Skipper> predicate;
-	/** Named placeholder for parsing a PDDL predicate expression. */
-	qi::rule<Iterator, Expression(), Skipper> pred_expression;
 	/** Named placeholder for parsing a PDDL value expression. */
 	qi::rule<Iterator, Expression(), Skipper> value_expression;
 	/** Named placeholder for parsing a PDDL numeric expression. */
 	qi::rule<Iterator, Expression(), Skipper> numeric_expression;
-	/** Named placeholder for parsing a PDDL function expression. */
-	qi::rule<Iterator, Expression(), Skipper> function_expression;
-	/** Named placeholder for parsing a PDDL function changing expression. */
-	qi::rule<Iterator, Expression(), Skipper> function_change_expression;
 	/** Named placeholder for parsing a PDDL bool expression. */
 	qi::rule<Iterator, Expression(), Skipper> bool_expression;
+	/** Named placeholder for parsing a PDDL function expression. */
+	qi::rule<Iterator, Expression(), Skipper> function_expression;
 	/** Named placeholder for parsing a PDDL durative expression. */
 	qi::rule<Iterator, Expression(), Skipper> durative_expression;
 	/** Named placeholder for parsing a PDDL quantified expression. */
 	qi::rule<Iterator, Expression(), Skipper> quantified_expression;
-	/** Named placeholder for parsing a PDDL conditional effect expression. */
-	qi::rule<Iterator, Expression(), Skipper> cond_effect_expression;
+	/** Named placeholder for parsing a PDDL predicate expression. */
+	qi::rule<Iterator, Expression(), Skipper> pred_expression;
 	/** Named placeholder for parsing an arbitrary  PDDL expression, where no semantic checks can be performed. */
 	qi::rule<Iterator, Expression(), Skipper> unknown_expression;
 	/** Named placeholder for parsing a PDDL expression. */

--- a/include/pddl_parser/pddl_parser.h
+++ b/include/pddl_parser/pddl_parser.h
@@ -31,7 +31,7 @@ namespace pddl_parser {
 class PddlParser
 {
 public:
-	static Domain     parseDomain(const std::string &pddl_domain, bool log_warnings = true);
+	static Domain     parseDomain(const std::string &pddl_domain);
 	static Problem    parseProblem(const std::string &pddl_problem);
 	static Expression parseFormula(const std::string &pddl_formula);
 

--- a/include/pddl_parser/pddl_parser.h
+++ b/include/pddl_parser/pddl_parser.h
@@ -22,10 +22,8 @@
 #ifndef PLUGINS_PDDL_PARSER_H_
 #define PLUGINS_PDDL_PARSER_H_
 
-#include "pddl_exception.h"
-#include "pddl_grammar.h"
+#include "pddl_ast.h"
 
-#include <boost/spirit/include/support_line_pos_iterator.hpp>
 #include <string>
 
 namespace pddl_parser {

--- a/include/pddl_parser/pddl_parser.h
+++ b/include/pddl_parser/pddl_parser.h
@@ -31,8 +31,9 @@ namespace pddl_parser {
 class PddlParser
 {
 public:
-	static Domain  parseDomain(const std::string &pddl_domain, bool log_warnings = true);
-	static Problem parseProblem(const std::string &pddl_problem);
+	static Domain     parseDomain(const std::string &pddl_domain, bool log_warnings = true);
+	static Problem    parseProblem(const std::string &pddl_problem);
+	static Expression parseFormula(const std::string &pddl_formula);
 
 private:
 	static std::string

--- a/pddl_parser.cpp
+++ b/pddl_parser.cpp
@@ -110,7 +110,7 @@ PddlParser::parseFormula(const std::string &pddl_formula)
  * @see Domain
  */
 Domain
-PddlParser::parseDomain(const std::string &pddl_domain, bool log_warnings)
+PddlParser::parseDomain(const std::string &pddl_domain)
 {
 	typedef pddl_parser::grammar::domain_parser<iterator_type> grammar;
 	typedef pddl_parser::grammar::pddl_skipper<iterator_type>  skipper;

--- a/pddl_parser.cpp
+++ b/pddl_parser.cpp
@@ -19,11 +19,13 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include <pddl_parser/pddl_exception.h>
+#include <pddl_parser/pddl_grammar.h>
 #include <pddl_parser/pddl_parser.h>
+#include <spdlog/spdlog.h>
 
 #include <fstream>
 #include <streambuf>
-#include <spdlog/spdlog.h>
 
 namespace pddl_parser {
 

--- a/pddl_semantics.cpp
+++ b/pddl_semantics.cpp
@@ -18,9 +18,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <pddl_parser/pddl_semantics.h>
-
 #include <pddl_parser/pddl_exception.h>
+#include <pddl_parser/pddl_semantics.h>
 
 #include <algorithm>
 
@@ -66,7 +65,7 @@ TypeSemantics::operator()(const iterator_type &where,
 }
 
 pair_type
-ParamTransformer::operator()(const iterator_type &    where,
+ParamTransformer::operator()(const iterator_type &,
                              const pair_strings_type &parsed,
                              string_pairs_type &      target) const
 {

--- a/tests/test_pddl_parser.cpp
+++ b/tests/test_pddl_parser.cpp
@@ -17,10 +17,9 @@
  *
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
+#include <gtest/gtest.h>
 #include <pddl_parser/pddl_exception.h>
 #include <pddl_parser/pddl_parser.h>
-
-#include <gtest/gtest.h>
 
 #include <filesystem>
 #include <fstream>
@@ -163,6 +162,26 @@ TEST(PddlParserTest, TypingTest)
 		  },
 		  PddlTypeException);
 	}
+}
+
+TEST(PddlParserTest, ParseFormula)
+{
+	PddlParser p;
+	Expression formula;
+	formula = p.parseFormula("(pred)");
+	EXPECT_EQ(formula.type, ExpressionType::PREDICATE);
+	EXPECT_EQ(boost::get<Predicate>(formula.expression).function, "pred");
+
+	formula = p.parseFormula("(and (pred1) (pred2))");
+	EXPECT_EQ(formula.type, ExpressionType::BOOL);
+	EXPECT_EQ(boost::get<Predicate>(formula.expression).function, "and");
+	ASSERT_EQ(boost::get<Predicate>(formula.expression).arguments.size(), 2);
+	EXPECT_EQ(boost::get<Predicate>(boost::get<Predicate>(formula.expression).arguments[0].expression)
+	            .function,
+	          "pred1");
+	EXPECT_EQ(boost::get<Predicate>(boost::get<Predicate>(formula.expression).arguments[1].expression)
+	            .function,
+	          "pred2");
 }
 
 TEST(PddlParserTest, MinimalDomain)


### PR DESCRIPTION
The formula parser parses a free-standing PDDL formula, which does not necessarily need to be part of the domain.

Also use the formula parser to parse the action preconditions in a domain.

Resolves #1.