### PR TITLE
Add pddl check executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,20 @@ cmake_minimum_required(VERSION 3.12)
 project(pddl_parser VERSION 0.9.0
 	DESCRIPTION "Basic PDDL parser based on boost spirit")
 
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED COMPONENTS system program_options)
 find_package(spdlog REQUIRED)
 
 add_library(pddl_parser SHARED pddl_parser.cpp pddl_semantics.cpp)
 target_link_libraries(pddl_parser PUBLIC Boost::boost Boost::system spdlog::spdlog)
 target_include_directories(
   pddl_parser PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-set_target_properties(pddl_parser PROPERTIES SOVERSION
-                                               ${PROJECT_VERSION_MAJOR})
+set_target_properties(pddl_parser PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+
+add_executable(pddl_check pddl_check.cpp)
+target_link_libraries(pddl_check PRIVATE pddl_parser Boost::program_options)
 
 include(GNUInstallDirs)
 
@@ -23,6 +26,11 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(DIRECTORY include/pddl_parser DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(
+  TARGETS pddl_check
+  EXPORT PddlParserTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/pddl_check.cpp
+++ b/pddl_check.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *  pddl_check.cpp - Check a PDDL domain for syntax errors
+ *
+ *  Created:   Wed  8 Dec 18:54:25 CET 2021
+ *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "pddl_parser/pddl_ast.h"
+#include "pddl_parser/pddl_parser.h"
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <filesystem>
+#include <fstream>
+#include <ostream>
+#include <spdlog/spdlog.h>
+
+namespace {
+std::string read_file(const std::filesystem::path &path) {
+  std::ifstream f;
+  f.open(path);
+  std::ostringstream sstr;
+  sstr << f.rdbuf();
+  return sstr.str();
+}
+} // namespace
+
+int main(int argc, const char *const argv[]) {
+  boost::program_options::options_description options("Allowed options");
+  std::filesystem::path domain_path;
+  std::filesystem::path problem_path;
+  using boost::program_options::value;
+  // clang-format off
+  options.add_options()
+    ("help,h", "Print help message")
+    ("domain", value(&domain_path), "The path to the domain file")
+    ("problem", value(&problem_path), "The path to the problem file")
+  ;
+  // clang-format on
+
+  boost::program_options::variables_map variables;
+  boost::program_options::store(
+      boost::program_options::parse_command_line(argc, argv, options),
+      variables);
+  boost::program_options::notify(variables);
+  if (variables.count("help")) {
+    std::cout << options;
+    return 0;
+  }
+  bool success = true;
+  if (!domain_path.empty()) {
+    try {
+      pddl_parser::PddlParser::parseDomain(read_file(domain_path));
+      std::cout << "Successfully parsed domain " << domain_path << '\n';
+    } catch (std::exception &e) {
+      std::cerr << "Failed to parse domain:\n" << e.what();
+      success = false;
+    }
+  }
+  if (!problem_path.empty()) {
+    try {
+      pddl_parser::PddlParser::parseProblem(read_file(problem_path));
+      std::cout << "Successfully parsed problem " << problem_path << '\n';
+    } catch (std::exception &e) {
+      std::cerr << "Failed to parse problem:\n" << e.what();
+      success = false;
+    }
+  }
+  return success ? 0 : 1;
+}

--- a/pddl_parser.spec.rpkg
+++ b/pddl_parser.spec.rpkg
@@ -38,6 +38,7 @@ This package contains necessary headers files for integrating the pddl_parser
 %files
 %license LICENSE.md
 %{_libdir}/libpddl_parser.so.*
+%{_bindir}/pddl_check
 
 %files devel
 %{_includedir}/pddl_parser


### PR DESCRIPTION
The executable tries to parse the given domain and problem and prints any errors by the parser.